### PR TITLE
Add macrobenchmark and microbenchmark modules

### DIFF
--- a/macrobenchmark/build.gradle.kts
+++ b/macrobenchmark/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+    id("com.android.test")
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.kerberos.trackingSdk.macrobenchmark"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 23
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":app"
+
+    buildTypes {
+        create("benchmark") {
+            isDebuggable = false
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += listOf("release")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlin {
+        jvmToolchain(17)
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.benchmark.macro)
+implementation(libs.androidx.junit)
+    implementation(libs.androidx.uiautomator)
+}

--- a/macrobenchmark/src/androidTest/java/com/kerberos/trackingSdk/benchmark/StartupBenchmark.kt
+++ b/macrobenchmark/src/androidTest/java/com/kerberos/trackingSdk/benchmark/StartupBenchmark.kt
@@ -1,0 +1,31 @@
+package com.kerberos.trackingSdk.benchmark
+
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StartupBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startup() {
+        benchmarkRule.measureRepeated(
+            packageName = "com.kerberos.trackingSdk",
+            metrics = listOf(StartupTimingMetric()),
+            iterations = 5,
+            startupMode = StartupMode.COLD,
+            compilationMode = CompilationMode.Partial()
+        ) {
+            pressHome()
+            startActivityAndWait()
+        }
+    }
+}

--- a/macrobenchmark/src/main/AndroidManifest.xml
+++ b/macrobenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+</manifest>

--- a/microbenchmark/build.gradle.kts
+++ b/microbenchmark/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
+}
+
+android {
+    namespace = "com.kerberos.trackingSdk.microbenchmark"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 23
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    testOptions {
+        targetSdk = 36
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlin {
+        jvmToolchain(17)
+    }
+}
+
+dependencies {
+    androidTestImplementation(libs.androidx.benchmark.junit4)
+    androidTestImplementation(libs.androidx.junit)
+}

--- a/microbenchmark/src/androidTest/java/com/kerberos/trackingSdk/benchmark/StringConcatBenchmark.kt
+++ b/microbenchmark/src/androidTest/java/com/kerberos/trackingSdk/benchmark/StringConcatBenchmark.kt
@@ -1,0 +1,26 @@
+package com.kerberos.trackingSdk.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StringConcatBenchmark {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    @Test
+    fun stringBuilderConcat() {
+        benchmarkRule.measureRepeated {
+            val result = StringBuilder()
+            for (i in 0 until 1_000) {
+                result.append(i)
+            }
+            result.toString()
+        }
+    }
+}

--- a/microbenchmark/src/main/AndroidManifest.xml
+++ b/microbenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.kerberos.trackingSdk.microbenchmark" />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,3 +27,5 @@ dependencyResolutionManagement {
 rootProject.name = "Tracking Application"
 include(":app")
 include(":liveTrackingSdk")
+include(":macrobenchmark")
+include(":microbenchmark")


### PR DESCRIPTION
### Motivation
- Add dedicated benchmarking modules so macro- and micro-performance tests can be authored and run against the app and library.

### Description
- Add a `:macrobenchmark` module configured with the `com.android.test` plugin, `targetProjectPath = ":app"`, a `benchmark` build type, and a `StartupBenchmark` macrobenchmark test (`macrobenchmark/build.gradle.kts`, `macrobenchmark/src/androidTest/.../StartupBenchmark.kt`).
- Add a `:microbenchmark` module configured as an Android library with a `StringConcatBenchmark` microbenchmark test (`microbenchmark/build.gradle.kts`, `microbenchmark/src/androidTest/.../StringConcatBenchmark.kt`).
- Register both modules in `settings.gradle.kts` via `include(":macrobenchmark")` and `include(":microbenchmark")`.
- Add required manifests and benchmark dependencies (`androidx.benchmark:benchmark-macro`, `androidx.benchmark:benchmark-junit4`, AndroidX JUnit, and UI Automator) in the new modules.

### Testing
- Attempted to discover tasks with `./gradlew :macrobenchmark:tasks --all :microbenchmark:tasks --all -q`, which failed early in this environment with a tooling/SDK error `25.0.2` and did not complete.
- No benchmark runs or other automated tests completed due to the above build/tooling error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08cea595648320bdb9f42348cfd6c2)